### PR TITLE
MSVC fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ cmake_minimum_required(VERSION 3.19)
 Project(InkStrokeModeler VERSION 0.1 LANGUAGES CXX)
 
 if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
-  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD 20)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
   option(INK_STROKE_MODELER_BUILD_TESTING "Build tests and testonly libraries" ON)
   option(INK_STROKE_MODELER_ENABLE_INSTALL "Enable install rule" ON)
@@ -83,9 +83,9 @@ else()
   FetchContent_MakeAvailable(absl)
 endif()
 
-if(CMAKE_CXX_STANDARD LESS 17)
+if(CMAKE_CXX_STANDARD LESS 20)
   message(FATAL_ERROR
-      "${PROJECT_NAME} requires CMAKE_CXX_STANDARD >= 17 (got: ${CMAKE_CXX_STANDARD})")
+      "${PROJECT_NAME} requires CMAKE_CXX_STANDARD >= 20 (got: ${CMAKE_CXX_STANDARD})")
 endif()
 
 include_directories("${CMAKE_SOURCE_DIR}")

--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ if you want to use a local checkout of Ink Stroke Modeler instead, use the
 [`local_repository`](https://bazel.build/reference/be/workspace#local_repository)
 workspace rule instead of `git_repository`.
 
-Since Ink Stroke Modler requires C++17, it must be built with
-`--cxxopt='-std=c++17'` (or similar indicating a newer version). You can put the
+Since Ink Stroke Modler requires C++20, it must be built with
+`--cxxopt='-std=c++20'` (or similar indicating a newer version). You can put the
 following in your project's `.bazelrc` to use this by default:
 
 ```none
-build --cxxopt='-std=c++17'
+build --cxxopt='-std=c++20'
 ```
 
 Then you can include the following in your targets' `deps`:
@@ -81,10 +81,10 @@ submodule:
 git submodule add https://github.com/google/ink-stroke-modeler
 ```
 
-And then include it in your `CMakeLists.txt`, requiring at least C++17:
+And then include it in your `CMakeLists.txt`, requiring at least C++20:
 
 ```cmake
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # If you want to use installed (or already fetched) versions of Abseil and/or
 # GTest (for example, if you've installed libabsl-dev and libgtest-dev), add:

--- a/ink_stroke_modeler/internal/validation.h
+++ b/ink_stroke_modeler/internal/validation.h
@@ -19,9 +19,11 @@ absl::Status ValidateIsFiniteNumber(T value, absl::string_view label) {
 
 template <typename T>
 absl::Status ValidateGreaterThanZero(T value, absl::string_view label) {
-  if (absl::Status status = ValidateIsFiniteNumber(value, label);
-      !status.ok()) {
-    return status;
+  if constexpr (std::is_floating_point_v<T>) {
+    if (absl::Status status = ValidateIsFiniteNumber(value, label);
+        !status.ok()) {
+      return status;
+    }
   }
   if (value <= 0) {
     return absl::InvalidArgumentError(absl::Substitute(

--- a/workspace.bzl
+++ b/workspace.bzl
@@ -40,11 +40,11 @@ local_repository(
     path = "path/to/ink-stroke-modeler",
 )
 
-Ink Stroke Modeler requires C++17. This is not currently the default for Bazel,
---cxxopt='-std=c++17' (or newer) is required. You can put the following in
+Ink Stroke Modeler requires C++20. This is not currently the default for Bazel,
+--cxxopt='-std=c++20' (or newer) is required. You can put the following in
 .bazelrc at your project's root:
 
-build --cxxopt='-std=c++17'
+build --cxxopt='-std=c++20'
 """
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")


### PR DESCRIPTION
- Bump the C++ std requirement from 17 to 20, since C++20 features are already used, but previously with a false claim of C++17 compatibility...
- Limit use of `isnan` and `isinf` to floating point types in ValidateGreaterThanZero