### PR TITLE
Fix CMakeLists.txt includes dir when using project with add_subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,7 @@ if(CMAKE_CXX_STANDARD LESS 20)
       "${PROJECT_NAME} requires CMAKE_CXX_STANDARD >= 20 (got: ${CMAKE_CXX_STANDARD})")
 endif()
 
-include_directories("${CMAKE_SOURCE_DIR}")
+include_directories("${CMAKE_CURRENT_SOURCE_DIR}")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 include(InkBazelEquivalents)
 


### PR DESCRIPTION
Otherwise the search directory is incorrrect and compilation failes with

```
fatal error: 'ink_stroke_modeler/internal/prediction/kalman_filter/kalman_filter.h' file not found
```